### PR TITLE
Fix #409 "Open in Explorer doesn't work for folders"

### DIFF
--- a/src/RoslynPad/DocumentTreeView.xaml.cs
+++ b/src/RoslynPad/DocumentTreeView.xaml.cs
@@ -56,7 +56,7 @@ namespace RoslynPad
             {
                 if (documentViewModel.IsFolder)
                 {
-                    _ = Task.Run(() => Process.Start(documentViewModel.Path));
+                    _ = Task.Run(() => Process.Start(new ProcessStartInfo { FileName = documentViewModel.Path, UseShellExecute = true }));
                 }
                 else
                 {


### PR DESCRIPTION
This will fix an issue when trying to open a folder from a documents pane (right click - open in file explorer). Currently the folder doesn't open.

Fixes #409