### PR TITLE
Add home folder to search dotnet sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Open `src\RoslynPad.sln` in Visual Studio 2019.
 * Install .NET Core SDK 6.0
 * Download and unzip `RoslynPadNetCore.zip`.
 * Run `dotnet RoslynPad.dll`
-> Optionaly you can add an Desktop entry based on file `roslynpad.desktop`
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Open `src\RoslynPad.sln` in Visual Studio 2019.
 * Install .NET Core SDK 6.0
 * Download and unzip `RoslynPadNetCore.zip`.
 * Run `dotnet RoslynPad.dll`
+> Optionaly you can add an Desktop entry based on file `roslynpad.desktop`
 
 ## Features
 

--- a/src/RoslynPad.Common.UI/PlatformsFactory.cs
+++ b/src/RoslynPad.Common.UI/PlatformsFactory.cs
@@ -76,7 +76,7 @@ namespace RoslynPad
             }
             else
             {
-                dotnetPaths = new[] { "/usr/share/dotnet", "/usr/local/share/dotnet" };
+                dotnetPaths = new[] { "/usr/share/dotnet", "/usr/local/share/dotnet", Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet") };
                 dotnetExe = "dotnet";
             }
 


### PR DESCRIPTION
Hi,
I was facing problems running the RoslynPadNetCore on Linux because the default installation path with bash script it's the Home folder, so I'd suggest adding this path to search SDK.
The script to install on linux: [dotnet-install.sh](https://dot.net/v1/dotnet-install.sh) and the [docs](https://docs.microsoft.com/en-us/dotnet/core/install/linux?WT.mc_id=dotnet-35129-website#manual-installation).
Also, I've added the .zip with the last release with this fix here: [RoslynPadNetCore 15.1](https://github.com/luigihenrick/roslynpad/releases/tag/15.1) may be useful to someone else.