### PR TITLE
Fix #255 - Add a new document by double-clicking on the toolbar

### DIFF
--- a/src/RoslynPad/App.xaml
+++ b/src/RoslynPad/App.xaml
@@ -14,6 +14,7 @@
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Resources/Icons.xaml" />
+                <ResourceDictionary Source="Resources/AvalonDockStyles.xaml" />
             </ResourceDictionary.MergedDictionaries>
 
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />

--- a/src/RoslynPad/MainWindow.xaml
+++ b/src/RoslynPad/MainWindow.xaml
@@ -66,6 +66,7 @@
                                      DocumentsSource="{Binding OpenDocuments, Mode=OneTime}"
                                      ActiveContent="{Binding CurrentOpenDocument, Mode=TwoWay}"
                                      DocumentClosing="DockingManager_OnDocumentClosing"
+                                     DocumentPaneControlStyle="{StaticResource DocumentPaneControlStyle}"
                                      AnchorableContextMenu="{x:Null}">
                     <dock:DockingManager.DocumentHeaderTemplate>
                         <DataTemplate>

--- a/src/RoslynPad/Resources/AvalonDockStyles.xaml
+++ b/src/RoslynPad/Resources/AvalonDockStyles.xaml
@@ -1,0 +1,163 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:dock="https://github.com/Dirkster99/AvalonDock"
+                    xmlns:roslyn="clr-namespace:Microsoft.CodeAnalysis;assembly=Microsoft.CodeAnalysis">
+
+    <!--  Default DocumentPaneControlStyle style in Dirkster99/AvalonDock/Themes/generic.xaml  -->
+    <Style x:Key="DocumentPaneControlStyle" TargetType="{x:Type dock:LayoutDocumentPaneControl}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type dock:LayoutDocumentPaneControl}">
+                    <Grid ClipToBounds="true"
+                          KeyboardNavigation.TabNavigation="Local"
+                          SnapsToDevicePixels="true">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <!--  Following border is required to catch mouse events  -->
+                        <Border Background="LightGray"
+                                Grid.RowSpan="2">
+                            <Border.InputBindings>
+                                <MouseBinding MouseAction="LeftDoubleClick"
+                                              Command="{Binding NewDocumentCommand, Mode=OneTime}"
+                                              CommandParameter="{x:Static roslyn:SourceCodeKind.Regular}" />
+                            </Border.InputBindings>
+                        </Border>
+                        <Grid Panel.ZIndex="1"
+                              Visibility="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type dock:LayoutDocumentPaneControl}}, Path=Model.ShowHeader, Converter={BoolToVisibilityConverter}}">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <dock:DocumentPaneTabPanel
+								x:Name="HeaderPanel"
+								Grid.Row="0"
+								Grid.Column="0"
+								IsItemsHost="true"
+								KeyboardNavigation.TabIndex="1" />
+                            <dock:DropDownButton
+								x:Name="MenuDropDownButton"
+								Grid.Column="1"
+								Focusable="False"
+								Style="{StaticResource {x:Static ToolBar.ToggleButtonStyleKey}}">
+                                <dock:DropDownButton.DropDownContextMenu>
+                                    <dock:ContextMenuEx ItemsSource="{Binding Model.ChildrenSorted, RelativeSource={RelativeSource TemplatedParent}}">
+                                        <dock:ContextMenuEx.ItemContainerStyle>
+                                            <Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="{x:Type dock:MenuItemEx}">
+                                                <Setter Property="HeaderTemplate" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplate}" />
+                                                <Setter Property="HeaderTemplateSelector" Value="{Binding Path=Root.Manager.DocumentPaneMenuItemHeaderTemplateSelector}" />
+                                                <Setter Property="IconTemplate" Value="{Binding Path=Root.Manager.IconContentTemplate}" />
+                                                <Setter Property="IconTemplateSelector" Value="{Binding Path=Root.Manager.IconContentTemplateSelector}" />
+                                                <Setter Property="Command" Value="{Binding Path=., Converter={ActivateCommandLayoutItemFromLayoutModelConverter}}" />
+                                            </Style>
+                                        </dock:ContextMenuEx.ItemContainerStyle>
+                                    </dock:ContextMenuEx>
+                                </dock:DropDownButton.DropDownContextMenu>
+                                <Border Background="White">
+                                    <Image Source="/AvalonDock;component/Themes/Generic/Images/PinDocMenu.png" />
+                                </Border>
+                            </dock:DropDownButton>
+                        </Grid>
+                        <Border
+							x:Name="ContentPanel"
+							Grid.Row="1"
+							Grid.Column="0"
+							HorizontalAlignment="Stretch"
+							VerticalAlignment="Stretch"
+							Background="{TemplateBinding Background}"
+							BorderBrush="{TemplateBinding BorderBrush}"
+							BorderThickness="{TemplateBinding BorderThickness}"
+							KeyboardNavigation.DirectionalNavigation="Contained"
+							KeyboardNavigation.TabIndex="2"
+							KeyboardNavigation.TabNavigation="Cycle">
+                            <ContentPresenter
+								x:Name="PART_SelectedContentHost"
+								Margin="{TemplateBinding Padding}"
+								ContentSource="SelectedContent"
+								SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                        </Border>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="false">
+                            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                        </Trigger>
+                        <DataTrigger Binding="{Binding RelativeSource={RelativeSource Mode=Self}, Path=Model.ChildrenCount}" Value="0">
+                            <Setter TargetName="MenuDropDownButton" Property="Visibility" Value="Collapsed" />
+                        </DataTrigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="ItemContainerStyle">
+            <Setter.Value>
+                <Style TargetType="{x:Type TabItem}">
+                    <Setter Property="Visibility" Value="{Binding IsVisible, Converter={BoolToVisibilityConverter}}" />
+                    <Setter Property="IsSelected" Value="{Binding IsSelected, Mode=TwoWay}" />
+                    <Setter Property="IsEnabled" Value="{Binding IsEnabled}" />
+                    <Setter Property="ToolTip" Value="{Binding ToolTip}" />
+                    <Setter Property="Padding" Value="2,0,2,0" />
+                    <Setter Property="Margin" Value="0,2,0,0" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type TabItem}">
+                                <Grid SnapsToDevicePixels="true">
+
+                                    <Border
+										x:Name="Bd"
+										Padding="{TemplateBinding Padding}"
+										Background="{TemplateBinding Background}"
+										BorderBrush="{TemplateBinding BorderBrush}"
+										BorderThickness="1,1,1,0">
+                                        <ContentPresenter
+											x:Name="Content"
+											HorizontalAlignment="{Binding HorizontalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+											VerticalAlignment="{Binding VerticalContentAlignment, RelativeSource={RelativeSource AncestorType={x:Type ItemsControl}}}"
+											ContentSource="Header"
+											RecognizesAccessKey="True"
+											SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                    </Border>
+                                </Grid>
+                                <ControlTemplate.Triggers>
+                                    <Trigger Property="Selector.IsSelected" Value="true">
+                                        <Setter Property="Background" Value="White" />
+                                        <Setter Property="Panel.ZIndex" Value="1" />
+                                        <Setter Property="Margin" Value="0,0,0,-2" />
+                                        <Setter TargetName="Content" Property="Margin" Value="0,0,0,3" />
+                                    </Trigger>
+                                    <MultiTrigger>
+                                        <MultiTrigger.Conditions>
+                                            <Condition Property="IsMouseOver" Value="true" />
+                                            <Condition Property="Selector.IsSelected" Value="false" />
+                                        </MultiTrigger.Conditions>
+                                        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.GradientInactiveCaptionBrushKey}}" />
+                                        <Setter Property="BorderBrush" Value="{DynamicResource {x:Static SystemColors.HighlightBrushKey}}" />
+                                        <Setter Property="Panel.ZIndex" Value="0" />
+                                    </MultiTrigger>
+                                    <Trigger Property="IsEnabled" Value="false">
+                                        <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="ItemTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <dock:LayoutDocumentTabItem Model="{Binding}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+
+        <Setter Property="ContentTemplate">
+            <Setter.Value>
+                <DataTemplate>
+                    <dock:LayoutDocumentControl Model="{Binding}" />
+                </DataTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+</ResourceDictionary>


### PR DESCRIPTION
Fix #255 - Added the ability to create a new document by double clicking on the toolbar

To add this feature, I took the default DocumentPaneControlStyle from Dirkster99/AvalonDock/Themes/generic.xaml to bind the NewDocumentCommand. 
Morever, I also changed the toolbar colour by "LightGray". However I can update this if you wish ;)


