### PR TITLE
Add keybind customization

### DIFF
--- a/src/RoslynPad.Common.UI/KeybindHelper.cs
+++ b/src/RoslynPad.Common.UI/KeybindHelper.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+
+namespace RoslynPad.UI
+{
+    public enum KEY_BIND//has to be top level to be bound to
+    {
+        RenameSymbol,
+        CommentSelection,
+        UncommentSelection,
+        FormatDocument,
+        SaveDocument,
+        TerminateRunningScript,
+        RunScript,
+        ResultsPanel_CopyValue,
+        ResultsPanel_CopyValueWithChildren,
+        NewCSDocument,
+        NewCSXScript,
+        OpenFile,
+        CloseCurrentFile,
+        ToggleDebugMode,
+        Search_ReplaceNext,
+        Search_ReplaceAll
+    }
+    public static class KeybindHelper
+    {
+        static KeybindHelper()
+        {
+            
+            keyBinds = new Dictionary<KEY_BIND, KnownKeyBind>();
+            AddKeyBind(KEY_BIND.RenameSymbol, "Rename Current Symbol", "F2");
+            AddKeyBind(KEY_BIND.CommentSelection, "Comment Selection", "Control+K");
+            AddKeyBind(KEY_BIND.UncommentSelection, "Un-Comment Selection", "Control+U");
+            AddKeyBind(KEY_BIND.FormatDocument, "Format Document", "Control+D");
+            AddKeyBind(KEY_BIND.SaveDocument, "Save Document", "Control+S");
+            AddKeyBind(KEY_BIND.TerminateRunningScript, "Terminate Running Script", "Shift+F5");
+            AddKeyBind(KEY_BIND.RunScript, "Run Script", "F5");
+            AddKeyBind(KEY_BIND.ResultsPanel_CopyValue, "Results Panel -> Copy Value", "Control+C");
+            AddKeyBind(KEY_BIND.ResultsPanel_CopyValueWithChildren, "Results Panel -> Copy Value with Children", "Control+Shift+C");
+            AddKeyBind(KEY_BIND.NewCSDocument, "New CS Document", "Control+N");
+            AddKeyBind(KEY_BIND.NewCSXScript, "New CSX Script", "Control+Shift+N");
+            AddKeyBind(KEY_BIND.OpenFile, "Open File", "Control+O");
+            AddKeyBind(KEY_BIND.CloseCurrentFile, "Close Currently Opened File", "Control+W");
+            AddKeyBind(KEY_BIND.ToggleDebugMode, "Toggle Debug/Optimization Mode", "Control+Shift+O");
+            AddKeyBind(KEY_BIND.Search_ReplaceNext, "Search -> Replace Next", "Alt+R");
+            AddKeyBind(KEY_BIND.Search_ReplaceAll, "Search -> Replace All", "Alt+A");
+        }
+        
+
+        public class KnownKeyBind
+        {
+            public KnownKeyBind(KEY_BIND name, string description, string defaultKey)
+            {
+                this.name = name;
+                this.description = description;
+                this.defaultKey = defaultKey;
+                this.currentKey = defaultKey;
+            }
+
+            public KEY_BIND name { get; }
+            public string description { get; }
+            public string defaultKey { get; }
+            public string currentKey { get; set; }
+        }
+        public static void SetKeyBindSequenceStr(KEY_BIND name, string sequence)
+        {
+            GetBindInfo(name).currentKey = sequence;
+        }
+        private static void AddKeyBind(KEY_BIND name, string description, string defaultKey)
+        {
+            keyBinds[name] = new KnownKeyBind(name, description, defaultKey);
+        }
+        private static Dictionary<KEY_BIND,KnownKeyBind> keyBinds;
+
+        public static string GetDescription(KEY_BIND name, bool withCurrentBind=false)
+        {
+            var info = GetBindInfo(name);
+            return $"{info.description}{(withCurrentBind ? $" ({info.currentKey})" : "")}";
+        }
+        public static string GetSequenceStr(KEY_BIND name)
+        {
+            return GetBindInfo(name).currentKey;
+        }
+        private static KnownKeyBind GetBindInfo(KEY_BIND name) => keyBinds[name];
+        public static void ReadOverrides(IApplicationSettingsValues settings)
+        {
+            var keyOverrides = settings.KeyBindOverrides;
+            if (keyOverrides == null)
+                keyOverrides = new Dictionary<string, string>();
+            foreach (var val in Enum.GetValues<KEY_BIND>())
+            {
+                var info = GetBindInfo(val);
+                if (keyOverrides.TryGetValue(val.ToString(), out var keyStr) && string.IsNullOrWhiteSpace(keyStr) == false)
+                    info.currentKey = keyStr;
+                else
+                    info.currentKey = info.defaultKey;
+            }
+        }
+        /*
+         *         converter = new KeyGestureConverter();
+        private static KeyGestureConverter converter;*/
+
+        //public static KeyGesture? GetGesture(KEY_BIND name)
+        //{
+        //    try
+        //    {
+        //        return (KeyGesture?) converter.ConvertFromString(GetSequenceStr(name));
+        //    }
+        //    catch {
+        //        return null;
+        //    }
+            
+        //}
+    }
+}

--- a/src/RoslynPad.Common.UI/Services/IApplicationSettingsValues.cs
+++ b/src/RoslynPad.Common.UI/Services/IApplicationSettingsValues.cs
@@ -4,6 +4,7 @@ namespace RoslynPad.UI
 {
     public interface IApplicationSettingsValues : INotifyPropertyChanged
     {
+        System.Collections.Generic.IDictionary<string, string>? KeyBindOverrides { get; set; }
         bool SendErrors { get; set; }
         bool EnableBraceCompletion { get; set; }
         string? LatestVersion { get; set; }

--- a/src/RoslynPad.Common.UI/ViewModels/MainViewModelBase.cs
+++ b/src/RoslynPad.Common.UI/ViewModels/MainViewModelBase.cs
@@ -290,16 +290,19 @@ namespace RoslynPad.UI
             OnPropertyChanged(nameof(CurrentOpenDocument));
         }
 
+        public string NewCSDocumentGesture => KeybindHelper.GetSequenceStr(KEY_BIND.NewCSDocument);
+        public string NewCSXScriptGesture => KeybindHelper.GetSequenceStr(KEY_BIND.NewCSXScript);
         public IDelegateCommand<SourceCodeKind> NewDocumentCommand { get; }
-
+        public string OpenFileGesture => KeybindHelper.GetSequenceStr(KEY_BIND.OpenFile);
         public IDelegateCommand OpenFileCommand { get; }
 
         public IDelegateCommand EditUserDocumentPathCommand { get; }
+        public string CloseCurrentDocumentGesture => KeybindHelper.GetSequenceStr(KEY_BIND.CloseCurrentFile);
 
         public IDelegateCommand CloseCurrentDocumentCommand { get; }
 
         public IDelegateCommand<OpenDocumentViewModel> CloseDocumentCommand { get; }
-
+        public string ToggleOptimizationGesture => KeybindHelper.GetSequenceStr(KEY_BIND.ToggleDebugMode);
         public IDelegateCommand ToggleOptimizationCommand { get; }
 
         public void OpenDocument(DocumentViewModel document)

--- a/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
+++ b/src/RoslynPad.Common.UI/ViewModels/OpenDocumentViewModel.cs
@@ -617,12 +617,19 @@ namespace RoslynPad.UI
         public NuGetDocumentViewModel NuGet { get; }
         public string Title => Document != null && !Document.IsAutoSaveOnly ? Document.Name : DefaultDocumentName + GetFileExtension();
         public IDelegateCommand OpenBuildPathCommand { get; }
+        public string SaveGesture => KeybindHelper.GetSequenceStr(KEY_BIND.SaveDocument);
         public IDelegateCommand SaveCommand { get; }
+        public string RunGesture => KeybindHelper.GetSequenceStr(KEY_BIND.RunScript);
         public IDelegateCommand RunCommand { get; }
+        public string TerminateGesture => KeybindHelper.GetSequenceStr(KEY_BIND.TerminateRunningScript);
         public IDelegateCommand TerminateCommand { get; }
+        public string FormatDocumentGesture => KeybindHelper.GetSequenceStr(KEY_BIND.FormatDocument);
         public IDelegateCommand FormatDocumentCommand { get; }
+        public string CommentSelectionGesture => KeybindHelper.GetSequenceStr(KEY_BIND.CommentSelection);
         public IDelegateCommand CommentSelectionCommand { get; }
+        public string UncommentSelectionGesture => KeybindHelper.GetSequenceStr(KEY_BIND.UncommentSelection);
         public IDelegateCommand UncommentSelectionCommand { get; }
+        public string RenameSymbolGesture => KeybindHelper.GetSequenceStr(KEY_BIND.RenameSymbol);
         public IDelegateCommand RenameSymbolCommand { get; }
 
         public bool IsRunning

--- a/src/RoslynPad/App.xaml
+++ b/src/RoslynPad/App.xaml
@@ -17,6 +17,9 @@
             </ResourceDictionary.MergedDictionaries>
 
             <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+            <converters:KeySequenceToGestureConverter x:Key="KeySequenceToGestureConverter" />
+            <converters:KeyBindToDescriptionConverter x:Key="KeyBindToDescriptionConverter" />
+            
             <converters:DoubleToPercentageTextConverter x:Key="DoubleToPercentageTextConverter" />
             <formatting:BooleanToVisibilityConverter x:Key="BooleanToVisibilityHiddenConverter"
                                                      FalseValue="Hidden" />

--- a/src/RoslynPad/Converters/KeySequenceToGestureConverter.cs
+++ b/src/RoslynPad/Converters/KeySequenceToGestureConverter.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Data;
+using System.Windows.Input;
+
+namespace RoslynPad.Converters
+{
+    public class KeyBindToDescriptionConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (parameter != null && parameter is UI.KEY_BIND keybind)
+                return UI.KeybindHelper.GetDescription(keybind, true);
+            return DependencyProperty.UnsetValue;
+        }
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+    public class KeySequenceToGestureConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            
+            if (value == null || value is not string s || string.IsNullOrWhiteSpace(s))
+                return DependencyProperty.UnsetValue;
+            try
+            {
+                var res = (KeyGesture?)converter.ConvertFromString(s);
+                if (res == null)
+                    return DependencyProperty.UnsetValue;
+                if (targetType == typeof(KeyGesture))
+                    return res;
+                if (targetType == typeof(ModifierKeys))
+                    return res.Modifiers;
+                if (targetType == typeof(Key))
+                    return res.Key;
+            }
+            catch { }
+            return DependencyProperty.UnsetValue;
+        }
+        private static KeyGestureConverter converter = new KeyGestureConverter();
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotImplementedException();
+    }
+}

--- a/src/RoslynPad/DocumentView.xaml
+++ b/src/RoslynPad/DocumentView.xaml
@@ -9,19 +9,26 @@
              mc:Ignorable="d"
              d:DataContext="{d:DesignInstance ui:OpenDocumentViewModel}">
     <FrameworkElement.InputBindings>
-        <KeyBinding Key="F5"
+        <KeyBinding Key="{Binding RunGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding RunGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding RunCommand, Mode=OneTime}" />
-        <KeyBinding Gesture="Shift+F5"
+        <KeyBinding Key="{Binding TerminateGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding TerminateGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding TerminateCommand, Mode=OneTime}" />
-        <KeyBinding Gesture="Ctrl+S"
+        <KeyBinding Key="{Binding SaveGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding SaveGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding SaveCommand, Mode=OneTime}" />
-        <KeyBinding Gesture="Ctrl+D"
+        <KeyBinding Key="{Binding FormatDocumentGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding FormatDocumentGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding FormatDocumentCommand, Mode=OneTime}" />
-        <KeyBinding Gesture="Ctrl+K"
+        <KeyBinding Key="{Binding CommentSelectionGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding CommentSelectionGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding CommentSelectionCommand, Mode=OneTime}" />
-        <KeyBinding Gesture="Ctrl+U"
+        <KeyBinding Key="{Binding UncommentSelectionGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding UncommentSelectionGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding UncommentSelectionCommand, Mode=OneTime}" />
-        <KeyBinding Gesture="F2"
+        <KeyBinding Key="{Binding RenameSymbolGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding RenameSymbolGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding RenameSymbolCommand, Mode=OneTime}" />
     </FrameworkElement.InputBindings>
     <DockPanel>
@@ -51,7 +58,7 @@
                      BorderBrush="DarkGray"
                      BorderThickness="0 0 0 1">
                 <Button Command="{Binding RunCommand, Mode=OneTime}"
-                        ToolTip="Run (F5)">
+                        ToolTip="{Binding Converter={StaticResource KeyBindToDescriptionConverter}, ConverterParameter={x:Static ui:KEY_BIND.RunScript}}">
                     <Grid>
                         <Image>
                             <Image.Style>

--- a/src/RoslynPad/MainWindow.xaml
+++ b/src/RoslynPad/MainWindow.xaml
@@ -18,17 +18,22 @@
         Name="This">
 
     <FrameworkElement.InputBindings>
-        <KeyBinding Gesture="Ctrl+N"
+        <KeyBinding Key="{Binding NewCSDocumentGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding NewCSDocumentGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding NewDocumentCommand, Mode=OneTime}"
                     CommandParameter="{x:Static roslyn:SourceCodeKind.Regular}" />
-        <KeyBinding Gesture="Ctrl+Shift+N"
+        <KeyBinding Key="{Binding NewCSXScriptGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding NewCSXScriptGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding NewDocumentCommand, Mode=OneTime}"
                     CommandParameter="{x:Static roslyn:SourceCodeKind.Script}" />
-        <KeyBinding Gesture="Ctrl+O"
+        <KeyBinding Key="{Binding OpenFileGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding OpenFileGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding OpenFileCommand, Mode=OneTime}" />
-        <KeyBinding Gesture="Ctrl+W"
+        <KeyBinding Key="{Binding CloseCurrentDocumentGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding CloseCurrentDocumentGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding CloseCurrentDocumentCommand, Mode=OneTime}" />
-        <KeyBinding Gesture="Ctrl+Shift+O"
+        <KeyBinding Key="{Binding ToggleOptimizationGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
+                    Modifiers="{Binding ToggleOptimizationGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"
                     Command="{Binding ToggleOptimizationCommand, Mode=OneTime}" />
     </FrameworkElement.InputBindings>
     <FrameworkElement.Resources>


### PR DESCRIPTION
Initial keybind customization work, note this is only configurable in the settings json but you can do things like:
```json
"KeyBindOverrides": {
  	"NewCSXScript": "Control+U",
  	"NewCSDocument": "Control+Shift+U"

  }
```
See the enum for all key binds.
Note: While I replaced all the UI Keybind calls in the two main docs for windows this is largely a POC commit.   I also show two examples of how this could be done.    One is where the view directly accesses a model data type, it is a bit cleaner IMOP but not exactly binding to the VM:

- `ToolTip="{Binding Converter={StaticResource KeyBindToDescriptionConverter}, ConverterParameter={x:Static ui:KEY_BIND.RunScript}}"`
- The other example is more MVVM and what i did for most but requires adding another field for each key bind to the viewmodel:
`Key="{Binding SaveGesture, Mode=OneTime, Converter={StaticResource KeySequenceToGestureConverter}}"` (with SaveGesture added to the VM)

You will also note some stupidity where I have to bind both Key and Modifiers separately, this is unavoidable I believe (as Gesture is not a dependency property).

Assuming you want this let me know which style you prefer ill update all the ones I can find in the code and update the PR.

Note: AvalonEdit does not support key bind changes easily either.  We can add binds but not really remove (I believe). I can make a PR on it though to add that support if we want to proceed to allow rebinding those too.