### PR TITLE
Fix #432 - Add the ModuleInitializer attribute also for .NET Frameworks

### DIFF
--- a/src/RoslynPad.Build/ExecutionHost.cs
+++ b/src/RoslynPad.Build/ExecutionHost.cs
@@ -266,7 +266,7 @@ namespace RoslynPad.Build
             }
             else
             {
-                if (Platform.FrameworkVersion?.Major < 5)
+                if (Platform.IsFramework || Platform.FrameworkVersion?.Major < 5)
                 {
                     syntaxTrees = syntaxTrees.Add(_moduleInitAttributeSyntax);
                 }


### PR DESCRIPTION
Fix #432 - Added ModuleInitializer attribute also for .NET Frameworks instead of considering only .NET Core below 5

When using the .NET Framework (x64) or (x86), the `Platform.FrameworkVersion` object is null
Therefore, the `ModuleInitializer `attribute is not added but we need it to avoid throwing an exception

This is why I added the condition "if Platform.IsFramework" in addition
`Platform.IsFramework` is only `true` for .NET versions and is `false` for .NET Core versions (and consequently also for .NET 5 and .NET 6 ;) )