### PR TITLE
Fix #433 - Excel Interop, Could not load file or assembly

### DIFF
--- a/src/RoslynPad.Build/ExecutionHost.cs
+++ b/src/RoslynPad.Build/ExecutionHost.cs
@@ -706,9 +706,16 @@ namespace RoslynPad.Build
 
                     cancellationToken.ThrowIfCancellationRequested();
 
+                    // Create a MetadataReferenceProperties with embedInteropTypes to true 
+                    // to integrate MS Office Interop types to the referencing compilation 
+                    // (only required for .Net Core)
+                    var metadataReferenceProperties = new MetadataReferenceProperties(embedInteropTypes: true);
+
                     MetadataReferences = references
                         .Where(r => !string.IsNullOrWhiteSpace(r))
-                        .Select(r => _roslynHost.CreateMetadataReference(r))
+                        .Select(r => Platform.IsCore && r.Contains(@"net20\Microsoft.Office.Interop") 
+                            ? _roslynHost.CreateMetadataReference(r, metadataReferenceProperties) 
+                            : _roslynHost.CreateMetadataReference(r))
                         .ToImmutableArray();
 
                     Analyzers = analyzers

--- a/src/RoslynPad.Roslyn/IRoslynHost.cs
+++ b/src/RoslynPad.Roslyn/IRoslynHost.cs
@@ -14,6 +14,6 @@ namespace RoslynPad.Roslyn
 
         void CloseDocument(DocumentId documentId);
 
-        MetadataReference CreateMetadataReference(string location);
+        MetadataReference CreateMetadataReference(string location, MetadataReferenceProperties properties = default);
     }
 }

--- a/src/RoslynPad.Roslyn/RoslynHost.cs
+++ b/src/RoslynPad.Roslyn/RoslynHost.cs
@@ -90,8 +90,8 @@ namespace RoslynPad.Roslyn
             preprocessorSymbols: PreprocessorSymbols,
             languageVersion: LanguageVersion.Preview);
 
-        public MetadataReference CreateMetadataReference(string location) => MetadataReference.CreateFromFile(location,
-            documentation: _documentationProviderService.GetDocumentationProvider(location));
+        public MetadataReference CreateMetadataReference(string location, MetadataReferenceProperties properties = default) => MetadataReference.CreateFromFile(location,
+            properties, _documentationProviderService.GetDocumentationProvider(location));
 
         private void OnDiagnosticsUpdated(object? sender, DiagnosticsUpdatedArgs diagnosticsUpdatedArgs)
         {


### PR DESCRIPTION
Fix #433 - Excel Interop, Could not load file or assembly

When we use Microsoft.Office.Interop.Excel.dll (or Word, PowerPoint, Outlook) with .Net Core, we get this error:
"Could not load file or assembly 'office, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c'. "

To resolve this error in a console application targeting .Net Core, we need: 
- Copy the DLL locally
- Go into the DLL properties
- Set the Embed Interop Types property to true

On the LinqPad side, the MS Office Interop DLLs work with .NET Core with LinqPad 6.5 and above 

On our side, we only need:
- Set the Embed Interop Types property to true when there is a reference to an MS Office Interop DLL.

This is possible with the `MetadataReferenceProperties struct` that I added as a parameter to IRoslynHost (previously we used the default value)