### PR TITLE
Added /usr/lib64/dotnet to search path for the dotnet sdk

### DIFF
--- a/src/RoslynPad.Common.UI/PlatformsFactory.cs
+++ b/src/RoslynPad.Common.UI/PlatformsFactory.cs
@@ -76,7 +76,7 @@ internal class PlatformsFactory : IPlatformsFactory
         }
         else
         {
-            dotnetPaths = new[] { "/usr/share/dotnet", "/usr/local/share/dotnet", Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet") };
+            dotnetPaths = new[] { "/usr/lib64/dotnet", "/usr/share/dotnet", "/usr/local/share/dotnet", Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet") };
             dotnetExe = "dotnet";
         }
 


### PR DESCRIPTION
Some linux distributions (namely Fedora and possibly other rpm based distros) install dotnet core into `/usr/lib64/dotnet`. The path is currently missing in the collection of paths searched for the dotnet sdk.

Fixes #470