### PR TITLE
Fix RoslynPad.Avalonia on Windows

### DIFF
--- a/src/RoslynPad.Runtime/RoslynPad.Runtime.csproj
+++ b/src/RoslynPad.Runtime/RoslynPad.Runtime.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <IsTrimmable>false</IsTrimmable>
     <PublishTrimmed>false</PublishTrimmed>
+    <TargetFramework Condition=" '$(TargetFramework)' != '' "></TargetFramework>
     <TargetFrameworks>$(EarliestSupportedTargetFramework);netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition=" '$(DefaultTargetFramework)' != '$(EarliestSupportedTargetFramework)' ">$(DefaultTargetFramework);$(TargetFrameworks)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Fixes `RoslynPad.Avalonia.sln` on Windows (tested in Rider).

The problem is that on Windows the following is being added in Directory.Build.props:

```xml
<UseWPF Condition=" $(MSBuildProjectName.Contains('Windows')) ">true</UseWPF>
<TargetFramework Condition=" '$(UseWPF)' == 'true' ">$(LtsTargetFramework)-windows</TargetFramework>
```

RoslynPad.Runtime.csproj is configured with TargetFrameworks:

```xml
<TargetFrameworks>$(EarliestSupportedTargetFramework);netstandard2.0</TargetFrameworks>
<TargetFrameworks Condition=" '$(DefaultTargetFramework)' != '$(EarliestSupportedTargetFramework)' ">$(DefaultTargetFramework);$(TargetFrameworks)</TargetFrameworks>
```

It seems that `<TargetFramework>` has higher priority than `<TargetFrameworks>`. Because of this the project is always being compiled using .NET 8.0 instead of the EarliestSupportedTargetFramework.

This PR resets the value of `<TargetFramework>` in RoslynPad.Runtime.csproj, causing the build to succeed.
