### PR TITLE
added logic to move window back onscreen if off screen on start

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100"
+    "version": "8.0.200"
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.56",

--- a/src/RoslynPad/MainWindow.xaml.cs
+++ b/src/RoslynPad/MainWindow.xaml.cs
@@ -3,7 +3,6 @@ using System.Composition.Hosting;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Xml.Linq;
@@ -135,8 +134,6 @@ public partial class MainWindow
     {
         var boundsString = _viewModel.Settings.WindowBounds;
 
-        //GetScreenAndWindowInfo();
-
         if (!string.IsNullOrEmpty(boundsString))
         {
             try
@@ -166,54 +163,10 @@ public partial class MainWindow
             FontSize = _viewModel.Settings.WindowFontSize.Value;
         }
 
-        ShiftWindowOntoScreen();
-    }
-
-    private void GetScreenAndWindowInfo()
-    {
-        var sb = new StringBuilder();
-
-        sb.AppendLine(_viewModel.Settings.WindowBounds);
-
-        var virtualScreenInfo = $"Virtual Screen: {SystemParameters.VirtualScreenLeft}, {SystemParameters.VirtualScreenTop}, {SystemParameters.VirtualScreenWidth}, {SystemParameters.VirtualScreenHeight}";
-
-        sb.AppendLine(virtualScreenInfo);
-
-        sb.AppendLine();
-        foreach (var s in System.Windows.Forms.Screen.AllScreens)
-        {
-            sb.AppendLine("Device Name: \t" + s.DeviceName);
-            sb.AppendLine("BitsPerPixel: \t" + s.BitsPerPixel);
-            sb.AppendLine("Bounds: \t\t" + s.Bounds);
-            sb.AppendLine("Primary: \t\t" + s.Primary);
-            sb.AppendLine("Working Area: \t" + s.WorkingArea);
-            sb.AppendLine("============================================================");
-        }
-
-        File.WriteAllText("temp.txt", sb.ToString());
-    }
-
-    private void ShiftWindowOntoScreen()
-    {
-        if (Top < SystemParameters.VirtualScreenTop)
-        {
-            Top = SystemParameters.VirtualScreenTop;
-        }
-
-        if (Left < SystemParameters.VirtualScreenLeft)
-        {
-            Left = SystemParameters.VirtualScreenLeft;
-        }
-
-        if (Left + Width > SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth)
-        {
-            Left = SystemParameters.VirtualScreenWidth + SystemParameters.VirtualScreenLeft - Width;
-        }
-
-        if (Top + Height > SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight)
-        {
-            Top = SystemParameters.VirtualScreenHeight + SystemParameters.VirtualScreenTop - Height;
-        }
+        Width = Math.Clamp(Width, 0, SystemParameters.VirtualScreenWidth);
+        Height = Math.Clamp(Height, 0, SystemParameters.VirtualScreenHeight);
+        Left = Math.Clamp(Left, SystemParameters.VirtualScreenLeft, SystemParameters.VirtualScreenWidth - Width);
+        Top = Math.Clamp(Top, SystemParameters.VirtualScreenTop, SystemParameters.VirtualScreenHeight - Height);
     }
 
     private void SaveWindowLayout()

--- a/src/RoslynPad/MainWindow.xaml.cs
+++ b/src/RoslynPad/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Composition.Hosting;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Xml.Linq;
@@ -133,6 +134,9 @@ public partial class MainWindow
     private void LoadWindowLayout()
     {
         var boundsString = _viewModel.Settings.WindowBounds;
+
+        //GetScreenAndWindowInfo();
+
         if (!string.IsNullOrEmpty(boundsString))
         {
             try
@@ -160,6 +164,55 @@ public partial class MainWindow
         if (_viewModel.Settings.WindowFontSize.HasValue)
         {
             FontSize = _viewModel.Settings.WindowFontSize.Value;
+        }
+
+        ShiftWindowOntoScreen();
+    }
+
+    private void GetScreenAndWindowInfo()
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine(_viewModel.Settings.WindowBounds);
+
+        var virtualScreenInfo = $"Virtual Screen: {SystemParameters.VirtualScreenLeft}, {SystemParameters.VirtualScreenTop}, {SystemParameters.VirtualScreenWidth}, {SystemParameters.VirtualScreenHeight}";
+
+        sb.AppendLine(virtualScreenInfo);
+
+        sb.AppendLine();
+        foreach (var s in System.Windows.Forms.Screen.AllScreens)
+        {
+            sb.AppendLine("Device Name: \t" + s.DeviceName);
+            sb.AppendLine("BitsPerPixel: \t" + s.BitsPerPixel);
+            sb.AppendLine("Bounds: \t\t" + s.Bounds);
+            sb.AppendLine("Primary: \t\t" + s.Primary);
+            sb.AppendLine("Working Area: \t" + s.WorkingArea);
+            sb.AppendLine("============================================================");
+        }
+
+        File.WriteAllText("temp.txt", sb.ToString());
+    }
+
+    private void ShiftWindowOntoScreen()
+    {
+        if (Top < SystemParameters.VirtualScreenTop)
+        {
+            Top = SystemParameters.VirtualScreenTop;
+        }
+
+        if (Left < SystemParameters.VirtualScreenLeft)
+        {
+            Left = SystemParameters.VirtualScreenLeft;
+        }
+
+        if (Left + Width > SystemParameters.VirtualScreenLeft + SystemParameters.VirtualScreenWidth)
+        {
+            Left = SystemParameters.VirtualScreenWidth + SystemParameters.VirtualScreenLeft - Width;
+        }
+
+        if (Top + Height > SystemParameters.VirtualScreenTop + SystemParameters.VirtualScreenHeight)
+        {
+            Top = SystemParameters.VirtualScreenHeight + SystemParameters.VirtualScreenTop - Height;
         }
     }
 


### PR DESCRIPTION
Related to https://github.com/roslynpad/roslynpad/issues/512

## Debug Info
- Debug info for multiple monitors: [multiScreen.txt](https://github.com/roslynpad/roslynpad/files/14515063/multiScreen.txt)
   - RoslynPad was moved onto attached monitor (not primary)
- Debug info for just primary monitor (built-in laptop screen): [SingleScreen.txt](https://github.com/roslynpad/roslynpad/files/14515089/SingleScreen.txt)
- Debug info when RoslynPad opened after being closed on secondary monitor and monitor was disconnected: [stuckOffScreen.txt](https://github.com/roslynpad/roslynpad/files/14515065/stuckOffScreen.txt)
   - window does not seem to respond to `Win+<Arrow Keys>` short cuts to move window to remaining screen

## Summary
Added a simple helper function based on https://stackoverflow.com/questions/37927011/in-wpf-how-to-shift-a-window-onto-the-screen-if-it-is-off-the-screen to move a window back onto a screen if it is out side of existing screen bounds.