### PR TITLE
Make sure the project is restored correctly

### DIFF
--- a/src/RoslynPad.Build/ExecutionHost.cs
+++ b/src/RoslynPad.Build/ExecutionHost.cs
@@ -738,7 +738,7 @@ internal partial class ExecutionHost : IExecutionHost, IDisposable
 
                 var outputPath = Path.Combine(projBuildResult.RestorePath, "output.json");
 
-                if (!projBuildResult.MarkerExists)
+                if (!projBuildResult.MarkerExists || !File.Exists(outputPath))
                 {
                     File.WriteAllText(Path.Combine(projBuildResult.RestorePath, "Program.cs"), "_ = 0;");
                     await BuildGlobalJson(projBuildResult.RestorePath).ConfigureAwait(false);


### PR DESCRIPTION
If parsing dotnet build fails (JSON deserialization), the ``output.json`` file cannot be created due to an exception. However, because the ``.restored`` file already exists, the error indicates ``MarkerExists=true``, causing all new scripts to fail to work properly.

There are 2 solutions
1. Delete cached project folders
2. Also check whether the ``output.json`` file exists. If it does not exist, build again.

PS
One of the scenarios that causes dotnet build parsing to fail is when the output content contains extra non-JSON content, e.g.

```
...
          "DefiningProjectDirectory": "C:\\Program Files\\dotnet\\sdk\\8.0.202\\",
          "DefiningProjectName": "Microsoft.Common.CurrentVersion",
          "DefiningProjectExtension": ".targets"
        }
      ]
    }
  }
}

有可用的工作负载更新。有关详细信息，请运行 `dotnet workload list`。
```
We can set environment variables by
```set DOTNET_CLI_WORKLOAD_UPDATE_NOTIFY_DISABLE=true```
Skip this check to avoid this content.
Or
You can also execute ``dotnet workload update`` to update the workload
