### PR TITLE
added usr/lib/dotnet path

### DIFF
--- a/src/RoslynPad.Common.UI/PlatformsFactory.cs
+++ b/src/RoslynPad.Common.UI/PlatformsFactory.cs
@@ -74,6 +74,7 @@ internal class PlatformsFactory : IPlatformsFactory
         {
             dotnetPaths.AddRange([
                 Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".dotnet"),
+                "/usr/lib/dotnet",
                 "/usr/lib64/dotnet",
                 "/usr/share/dotnet",
                 "/usr/local/share/dotnet",


### PR DESCRIPTION
improves #499 situation by including `/usr/lib/dotnet` path (enhancement).


