### PR TITLE
Fix #543 - Bind font family of editor and IL window to user config

### DIFF
--- a/src/RoslynPad.Avalonia/DocumentView.axaml.cs
+++ b/src/RoslynPad.Avalonia/DocumentView.axaml.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.Text;
 using RoslynPad.Editor;
 using RoslynPad.Build;
 using RoslynPad.UI;
+using Avalonia.Media;
 
 namespace RoslynPad;
 
@@ -18,28 +19,11 @@ partial class DocumentView : UserControl, IDisposable
         InitializeComponent();
 
         _editor = this.FindControl<RoslynCodeEditor>("Editor") ?? throw new InvalidOperationException("Missing Editor");
-        _editor.FontFamily = GetPlatformFontFamily();
 
         DataContextChanged += OnDataContextChanged;
     }
 
     public OpenDocumentViewModel ViewModel => _viewModel.NotNull();
-
-    private static string GetPlatformFontFamily()
-    {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-        {
-            return "Consolas";
-        }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            return "Menlo";
-        }
-        else
-        {
-            return "Monospace";
-        }
-    }
 
     private async void OnDataContextChanged(object? sender, EventArgs args)
     {
@@ -53,6 +37,7 @@ partial class DocumentView : UserControl, IDisposable
         viewModel.MainViewModel.EditorFontSizeChanged += size => _editor.FontSize = size;
         viewModel.MainViewModel.ThemeChanged += OnThemeChanged;
         _editor.FontSize = viewModel.MainViewModel.EditorFontSize;
+        _editor.FontFamily = new FontFamily(viewModel.MainViewModel.EditorFontFamily);
 
         var documentText = await viewModel.LoadTextAsync().ConfigureAwait(true);
 

--- a/src/RoslynPad.Avalonia/FontFamilyValidator.cs
+++ b/src/RoslynPad.Avalonia/FontFamilyValidator.cs
@@ -1,0 +1,24 @@
+﻿using RoslynPad.UI.Services;
+using Avalonia.Media;
+using RoslynPad.UI;
+using System.Composition;
+
+namespace RoslynPad;
+
+[Export(typeof(IFontFamilyValidator)), Shared]
+internal class FontFamilyValidator : IFontFamilyValidator
+{
+    public bool IsValid(string fontFamilyName)
+    {
+        try
+        {
+            var fontFamily = FontFamily.Parse(fontFamilyName);
+
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/src/RoslynPad.Common.UI/Services/IApplicationSettingsValues.cs
+++ b/src/RoslynPad.Common.UI/Services/IApplicationSettingsValues.cs
@@ -12,6 +12,7 @@ public interface IApplicationSettingsValues : INotifyPropertyChanged
     string? DockLayout { get; set; }
     string? WindowState { get; set; }
     double EditorFontSize { get; set; }
+    string EditorFontFamily { get; set; }
     double OutputFontSize { get; set; }
     string? DocumentPath { get; set; }
     bool SearchFileContents { get; set; }

--- a/src/RoslynPad.Common.UI/Services/IFontFamilyValidator.cs
+++ b/src/RoslynPad.Common.UI/Services/IFontFamilyValidator.cs
@@ -1,0 +1,6 @@
+﻿namespace RoslynPad.UI.Services;
+
+public interface IFontFamilyValidator
+{
+    bool IsValid(string fontFamilyName);
+}

--- a/src/RoslynPad.Common.UI/ViewModels/MainViewModel.cs
+++ b/src/RoslynPad.Common.UI/ViewModels/MainViewModel.cs
@@ -29,6 +29,7 @@ public abstract class MainViewModel : NotificationObject, IDisposable
     private OpenDocumentViewModel? _currentOpenDocument;
     private bool _hasUpdate;
     private double _editorFontSize;
+    private string _editorFontFamily;
     private string? _searchText;
     private bool _isWithinSearchResults;
     private bool _isInitialized;
@@ -94,6 +95,7 @@ public abstract class MainViewModel : NotificationObject, IDisposable
         ClearRestoreCacheCommand = commands.Create(ClearRestoreCache);
 
         _editorFontSize = Settings.EditorFontSize;
+        _editorFontFamily = Settings.EditorFontFamily;
 
         _documentRoot = CreateDocumentRoot();
 
@@ -543,8 +545,22 @@ public abstract class MainViewModel : NotificationObject, IDisposable
         }
     }
 
+    public string EditorFontFamily
+    {
+        get => _editorFontFamily;
+        set
+        {        
+            if (SetProperty(ref _editorFontFamily, value))
+            {
+                Settings.EditorFontFamily = value;
+                EditorFontFamilyChanged?.Invoke(value);
+            }
+        }
+    }
+
 
     public event Action<double>? EditorFontSizeChanged;
+    public event Action<string>? EditorFontFamilyChanged;
 
     public DocumentViewModel AddDocument(string documentName)
     {

--- a/src/RoslynPad/Controls/ILViewer.xaml
+++ b/src/RoslynPad/Controls/ILViewer.xaml
@@ -8,6 +8,5 @@
              d:DesignHeight="300"
              d:DesignWidth="300">
     <avalonedit:TextEditor Name="TextEditor"
-                           FontFamily="Cascadia Code"
                            IsReadOnly="True" />
 </UserControl>

--- a/src/RoslynPad/DocumentView.xaml
+++ b/src/RoslynPad/DocumentView.xaml
@@ -254,7 +254,6 @@
             <editor:RoslynCodeEditor x:Name="Editor"
                                      x:FieldModifier="private"
                                      ContextActionsIcon="{StaticResource Bulb}"
-                                     FontFamily="Cascadia Code"
                                      Background="{DynamicResource {x:Static rp:ThemeDictionary.EditorBackground}}"
                                      Foreground="{DynamicResource {x:Static rp:ThemeDictionary.EditorForeground}}"
                                      Grid.Row="1"

--- a/src/RoslynPad/DocumentView.xaml.cs
+++ b/src/RoslynPad/DocumentView.xaml.cs
@@ -72,6 +72,7 @@ public partial class DocumentView : IDisposable
 
         _viewModel.MainViewModel.EditorFontSizeChanged += EditorFontSizeChanged;
         Editor.FontSize = _viewModel.MainViewModel.EditorFontSize;
+        Editor.FontFamily = new FontFamily(_viewModel.MainViewModel.EditorFontFamily);
 
         var documentText = await _viewModel.LoadTextAsync().ConfigureAwait(true);
 

--- a/src/RoslynPad/FontFamilyValidator.cs
+++ b/src/RoslynPad/FontFamilyValidator.cs
@@ -1,0 +1,17 @@
+﻿using System.Composition;
+using System.Drawing;
+using RoslynPad.UI;
+using RoslynPad.UI.Services;
+
+namespace RoslynPad;
+
+[Export(typeof(IFontFamilyValidator)), Shared]
+internal class FontFamilyValidator : IFontFamilyValidator
+{
+    public bool IsValid(string fontFamilyName)
+    {
+        var fontFamily = new FontFamily(fontFamilyName);
+        
+        return fontFamily.IsStyleAvailable(FontStyle.Regular);
+    }
+}

--- a/src/RoslynPad/MainWindow.xaml
+++ b/src/RoslynPad/MainWindow.xaml
@@ -138,6 +138,7 @@
                                             <AdornerDecorator DataContext="{Binding CurrentOpenDocument}">
                                                 <controls:ILViewer Text="{Binding ILText}"
                                                                    IsVisibleChanged="ILViewer_IsVisibleChanged"
+                                                                   FontFamily="{Binding MainViewModel.EditorFontFamily}"
                                                                    FontSize="{Binding MainViewModel.EditorFontSize}" />
                                             </AdornerDecorator>
                                         </DockPanel>


### PR DESCRIPTION
This PR moves the font family into the `RoslynPad.json` config to allow the user to override the value.
 - A default value is generated depending on the hosts OS platform. On Windows, the default value is set to `Cascadia Code` (the current default) and if that Font Family is not available, it will default to `Consolas`.
 - Seeing as `System.Drawing.FontFamily` is Windows only, a new interface was required to abstract out the font family validation to the corresponding UI Host (Avalonia, or WPF). 
 - This fixes the issue #543 that crashes the RoslynPad UI if the `Cascadia Code` font family cannot be accessed for whatever reason. While the issue does not have a direct fix, allowing the user to change the font for the UI in the config will provide a way for users to mitigate the issue. (It also provides UI customisability in case the user wants to use their own installed font).

Media:
![image](https://github.com/user-attachments/assets/0938b624-7de5-420a-ad6e-53fbf53515e2)

![image](https://github.com/user-attachments/assets/65b96a2e-bde3-49f9-823f-f93f10d56ddc)

Fixes #543