### PR TITLE
Fixed incorrect character encoding in error messages of build-warning…

### DIFF
--- a/src/RoslynPad.Build/ExecutionHost.cs
+++ b/src/RoslynPad.Build/ExecutionHost.cs
@@ -290,7 +290,7 @@ internal partial class ExecutionHost : IExecutionHost, IDisposable
 
         var buildArgs =
             $"-nologo -v:q -p:Configuration={optimizationLevel} \"-p:AssemblyName={Name}\" " +
-            $"\"-flp1:logfile={buildWarningsPath};warningsonly\" \"-flp2:logfile={buildErrorsPath};errorsonly\" \"{csprojPath}\" ";
+            $"\"-flp1:logfile={buildWarningsPath};warningsonly;Encoding=UTF-8\" \"-flp2:logfile={buildErrorsPath};errorsonly;Encoding=UTF-8\" \"{csprojPath}\" ";
         using var buildResult = await ProcessUtil.RunProcessAsync(DotNetExecutable, BuildPath,
             $"build {buildArgs}", cancellationToken).ConfigureAwait(false);
         await buildResult.WaitForExitAsync().ConfigureAwait(false);
@@ -793,7 +793,7 @@ internal partial class ExecutionHost : IExecutionHost, IDisposable
 
                     var buildArgs =
                         $"--interactive -nologo " +
-                        $"-flp:errorsonly;logfile=\"{restoreErrorsPath}\" \"{projBuildResult.CsprojPath}\" " +
+                        $"-flp:errorsonly;logfile=\"{restoreErrorsPath}\";Encoding=UTF-8 \"{projBuildResult.CsprojPath}\" " +
                         $"-getTargetResult:build -getItem:ReferencePathWithRefAssemblies,Analyzer ";
                     using var restoreResult = await ProcessUtil.RunProcessAsync(DotNetExecutable, BuildPath,
                         $"build {buildArgs}", cancellationToken).ConfigureAwait(false);

--- a/src/RoslynPad.Build/ProcessUtil.cs
+++ b/src/RoslynPad.Build/ProcessUtil.cs
@@ -18,6 +18,8 @@ internal class ProcessUtil
                 RedirectStandardError = true,
                 CreateNoWindow = true,
                 UseShellExecute = false,
+                StandardOutputEncoding = Encoding.UTF8,
+                StandardErrorEncoding = Encoding.UTF8,
             },
             EnableRaisingEvents = true,
         };


### PR DESCRIPTION
…s log or  build-errors log

when occuring restore or build error, the log shown will be incorrect characters because of encoding, such as the follow issue link, I add encoding-utf8 in buildargs to fix.
* bug https://github.com/roslynpad/roslynpad/issues/588#issue-2933677562
Fixes #558


