### PR TITLE
Improve completion selection logic in CompletionWindow

### DIFF
--- a/src/RoslynPad.Editor.Windows/Shared/CodeTextEditor.cs
+++ b/src/RoslynPad.Editor.Windows/Shared/CodeTextEditor.cs
@@ -302,7 +302,7 @@ public partial class CodeTextEditor : TextEditor
                 else
                 {
                     // Select first item
-                    if (_completionWindow.CompletionList.CompletionData.FirstOrDefault(v => true) is { } firstCompletionItem)
+                    if (_completionWindow.CompletionList.CompletionData.FirstOrDefault() is { } firstCompletionItem)
                     {
                         _completionWindow.CompletionList.SelectedItem = firstCompletionItem;
                         _completionWindow.CompletionList.ScrollIntoView(firstCompletionItem);

--- a/src/RoslynPad.Editor.Windows/Shared/CodeTextEditor.cs
+++ b/src/RoslynPad.Editor.Windows/Shared/CodeTextEditor.cs
@@ -294,7 +294,20 @@ public partial class CodeTextEditor : TextEditor
 
             try
             {
-                _completionWindow.CompletionList.SelectedItem = selected;
+                if (selected != null)
+                {
+                    _completionWindow.CompletionList.SelectedItem = selected;
+                    _completionWindow.CompletionList.ScrollIntoView(selected);
+                }
+                else
+                {
+                    // Select first item
+                    if (_completionWindow.CompletionList.CompletionData.FirstOrDefault(v => true) is { } firstCompletionItem)
+                    {
+                        _completionWindow.CompletionList.SelectedItem = firstCompletionItem;
+                        _completionWindow.CompletionList.ScrollIntoView(firstCompletionItem);
+                    }
+                }
             }
             catch (Exception)
             {


### PR DESCRIPTION
## Thank you for contributing to RoslynPad!

Please reference an existing issue with one of the following labels:
* When `CompletionProvider.GetCompletionData()` returns no selected item, the first item is selected by default (consistent with Visual Studio behavior).
*  When triggering completion at `[StructLayout(`, the ScrollViewer correctly scrolls to `LayoutKind`  

<br/>

before:
<img width="493" height="173" alt="{C7DB3F86-8008-40A9-82AC-EB05C9D9EE74}" src="https://github.com/user-attachments/assets/97a0c742-ee06-449f-95ec-c5e1deb42be5" />\

after:
<img width="499" height="169" alt="{7FA7FBC2-698D-4231-8C26-85A8F41F4140}" src="https://github.com/user-attachments/assets/0390b51d-37ce-404d-864f-8e9f8f4cfce9" />

<br/>

before:
<img width="891" height="424" alt="{99AE4BD8-DDEE-44D8-BACC-EAAFFFF5E91D}" src="https://github.com/user-attachments/assets/1c99dd94-d471-4b47-be55-bcdf15071eb3" />

after:
<img width="582" height="429" alt="image" src="https://github.com/user-attachments/assets/79977a0c-6bea-439c-b139-5a509b0ea2fe" />


If you would like to contribute something new, please discuss it in an issue first.
