### PR TITLE
Sort CompletionList

### DIFF
--- a/src/RoslynPad.Editor.Windows/Shared/CompletionResult.cs
+++ b/src/RoslynPad.Editor.Windows/Shared/CompletionResult.cs
@@ -1,10 +1,10 @@
 ﻿namespace RoslynPad.Editor;
 
-public sealed class CompletionResult(IList<ICompletionDataEx>? completionData, IOverloadProviderEx? overloadProvider, bool useHardSelection)
+public sealed class CompletionResult(IReadOnlyList<ICompletionDataEx>? completionData, IOverloadProviderEx? overloadProvider, bool useHardSelection)
 {
     public bool UseHardSelection { get; } = useHardSelection;
 
-    public IList<ICompletionDataEx>? CompletionData { get; } = completionData;
+    public IReadOnlyList<ICompletionDataEx>? CompletionData { get; } = completionData;
 
     public IOverloadProviderEx? OverloadProvider { get; } = overloadProvider;
 }


### PR DESCRIPTION
## Thank you for contributing to RoslynPad!

Please reference an existing issue with one of the following labels:
* Sort CompletionList
* Change `CompletionResult.CompletionData` from `IList<>` to `IReadOnlyList<>`

before:
<img width="469" height="420" alt="image" src="https://github.com/user-attachments/assets/a0952169-5269-4457-9832-7fdc6c11745f" />

after:
<img width="434" height="421" alt="image" src="https://github.com/user-attachments/assets/1788609e-ccc9-43d3-874a-957f3172cf07" />


If you would like to contribute something new, please discuss it in an issue first.
