### PR TITLE
Keep the vertical scrollbar thumb draggable

### DIFF
--- a/src/Morgania.Editor/Editor/Margins.cs
+++ b/src/Morgania.Editor/Editor/Margins.cs
@@ -272,6 +272,7 @@ public sealed class VerticalScrollBarMarginProvider : IWpfTextViewMarginProvider
         private readonly IWpfTextView _view;
         private readonly LineScrollMap _map;
         private bool _synchronizing;
+        private bool _thumbDragging;
 
         public VerticalScrollBarMargin(IWpfTextView view)
         {
@@ -285,6 +286,12 @@ public sealed class VerticalScrollBarMarginProvider : IWpfTextViewMarginProvider
             view.LayoutChanged += (_, _) => SynchronizeFromView();
             Scroll += (_, e) =>
             {
+                // While the thumb is being dragged the drag owns Value: the layout sync must
+                // not write it back — its whole-line quantization would round away every
+                // sub-line drag delta, so the thumb sticks and the view crawls far behind the
+                // pointer. Any other scroll (EndScroll on release, paging, line steps) hands
+                // Value back to the sync, which settles it on a line boundary.
+                _thumbDragging = e.ScrollEventType == ScrollEventType.ThumbTrack;
                 if (!_synchronizing && !_view.IsClosed)
                 {
                     _view.DisplayTextLineContainingBufferPosition(
@@ -385,7 +392,10 @@ public sealed class VerticalScrollBarMarginProvider : IWpfTextViewMarginProvider
                 Maximum = Math.Max(0.0, _view.VisualSnapshot.LineCount - viewportLines);
                 ViewportSize = viewportLines;
                 LargeChange = viewportLines;
-                Value = firstLine;
+                if (!_thumbDragging)
+                {
+                    Value = firstLine;
+                }
             }
             finally
             {


### PR DESCRIPTION
Dragging the editor's vertical scrollbar thumb feels sticky: it moves far less than the pointer and appears to stall.

`VerticalScrollBarMargin.SynchronizeFromView` runs on every view layout and writes `Value = firstLine`, quantized to whole lines. During a thumb drag, each drag delta produces a fractional `Value`, the margin's `Scroll` handler displays the (line-quantized) position, the resulting layout re-syncs, and the snap-back rounds away every sub-line delta — the drag only advances when a single delta happens to cross a rounding boundary.

Fix: track `ThumbTrack` scroll events and skip the `Value` write-back while the thumb is being dragged. The view itself stays line-quantized, `Maximum`/`ViewportSize`/`LargeChange` keep syncing, and any other scroll gesture (`EndScroll` on release, paging, line steps) hands `Value` back to the sync, which settles it on a line boundary.

Diagnosed with an event trace of the bar's `Scroll`/property churn during a drag; verified in a downstream Avalonia host embedding the editor.

Note: Claude Fable 5 Max (Anthropic) was used in developing this change. Please feel free to edit or rework this PR in any way.