### PR TITLE
Sync the horizontal scrollbar on purely horizontal scrolls

### DIFF
--- a/src/Morgania.Editor/Editor/Margins.cs
+++ b/src/Morgania.Editor/Editor/Margins.cs
@@ -473,6 +473,9 @@ public sealed class HorizontalScrollBarMarginProvider : IWpfTextViewMarginProvid
             AllowAutoHide = false;
             Minimum = 0.0;
             view.LayoutChanged += (_, _) => SynchronizeFromView();
+            // A purely horizontal scroll (wheel tilt, Shift+wheel) shifts the viewport without
+            // re-laying-out the lines — no LayoutChanged — so the thumb must follow this event.
+            view.ViewportLeftChanged += (_, _) => SynchronizeFromView();
             view.Options.OptionChanged += (_, _) => SynchronizeFromView();
             Scroll += (_, e) =>
             {


### PR DESCRIPTION
The horizontal scrollbar's thumb does not follow purely horizontal scrolling (wheel tilt, or Shift+wheel once supported): the content moves but the thumb stays put until the next layout.

`HorizontalScrollBarMargin` only re-syncs on `LayoutChanged`, but a purely horizontal scroll shifts `ViewportLeft` without re-laying-out any lines — that path raises `ViewportLeftChanged`, which the margin never subscribed to. (Thumb drags looked fine only because the thumb itself was the source of those moves.)

Fix: also synchronize on `ViewportLeftChanged`.

Note: Claude Fable 5 Max (Anthropic) was used in developing this change. Please feel free to edit or rework this PR in any way.