### PR TITLE
Scroll horizontally with Shift+wheel

### DIFF
--- a/src/Morgania.Editor/Editor/WpfTextView.cs
+++ b/src/Morgania.Editor/Editor/WpfTextView.cs
@@ -1225,6 +1225,15 @@ internal sealed class WpfTextView : Panel, IWpfTextView, ITextView2
             return;
         }
 
+        // Shift+wheel scrolls horizontally (the standard editor gesture for mice without a
+        // tilt wheel): the wheel's vertical notches take the horizontal mapping below.
+        if (!_isClosed && e.Delta.Y != 0 && e.KeyModifiers.HasFlag(KeyModifiers.Shift))
+        {
+            _viewScroller.ScrollViewportHorizontallyByPixels(-e.Delta.Y * 3.0 * LineHeight);
+            e.Handled = true;
+            return;
+        }
+
         if (!_isClosed && e.Delta.Y != 0)
         {
             _viewScroller.ScrollViewportVerticallyByPixels(e.Delta.Y * 3.0 * LineHeight);


### PR DESCRIPTION
Adds the standard editor gesture for mice without a tilt wheel: holding Shift maps the wheel's vertical notches onto horizontal scrolling, with the same distance mapping the tilt wheel already uses (and the same direction convention: Shift+wheel-down scrolls right). Ctrl/Cmd+wheel zoom keeps precedence.

Because it lives in `WpfTextView.HandleMouseWheel`, the gesture works everywhere wheel input funnels through the view — including over the scrollbar margins and the IntelliSense popups.

Note: Claude Fable 5 Max (Anthropic) was used in developing this change. Please feel free to edit or rework this PR in any way.