### PR TITLE
Fix the horizontal scrollbar scrolling past the content and under the vertical scrollbar

### DIFF
--- a/src/Morgania.Editor/Editor/Margins.cs
+++ b/src/Morgania.Editor/Editor/Margins.cs
@@ -533,7 +533,7 @@ public sealed class HorizontalScrollBarMarginProvider : IWpfTextViewMarginProvid
             try
             {
                 IsVisible = Enabled;
-                Maximum = Math.Max(0.0, _view.MaxTextRightCoordinate + 20.0 - _view.ViewportWidth);
+                Maximum = Math.Max(0.0, _view.MaxTextRightCoordinate + _view.FormattedLineSource.ColumnWidth - _view.ViewportWidth);
                 ViewportSize = Math.Max(1.0, _view.ViewportWidth);
                 LargeChange = _view.ViewportWidth;
                 SmallChange = 16.0;

--- a/src/Morgania.Editor/Editor/WpfTextViewHost.cs
+++ b/src/Morgania.Editor/Editor/WpfTextViewHost.cs
@@ -71,6 +71,8 @@ internal sealed class WpfTextViewHost : IWpfTextViewHost
         right.VisualElement.HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Right;
         AddCell(right.VisualElement, row: 1, column: 1);
         bottom.VisualElement.VerticalAlignment = Avalonia.Layout.VerticalAlignment.Bottom;
+        right.VisualElement.SizeChanged += (_, e) =>
+            bottom.VisualElement.Margin = new Avalonia.Thickness(0.0, 0.0, e.NewSize.Width, 0.0);
         AddCell(bottom.VisualElement, row: 1, column: 1);
 
         if (setFocus)

--- a/tests/Morgania.BehaviorTests/MarginTests.cs
+++ b/tests/Morgania.BehaviorTests/MarginTests.cs
@@ -58,6 +58,60 @@ public sealed class MarginTests
     }
 
     [TestMethod]
+    public async Task HorizontalScrollBarDragCeilingMatchesTheViewportClamp()
+    {
+        await HeadlessEditor.RunAsync(() =>
+        {
+            // One line far wider than the viewport.
+            var view = HeadlessEditor.CreateView(new string('x', 400), width: 200.0, height: 100.0);
+            var factory = HeadlessEditor.Container.GetExport<ITextEditorFactoryService>();
+            var host = factory.CreateTextViewHost(view, setFocus: false);
+            var scrollBar = (Avalonia.Controls.Primitives.ScrollBar)
+                host.GetTextViewMargin(PredefinedMarginNames.HorizontalScrollBar)!.VisualElement;
+
+            // Scroll as far as the view itself allows (the wheel / keyboard path)...
+            view.ViewportLeft = double.MaxValue;
+
+            // ...and the scrollbar's drag range must end exactly there.
+            Assert.AreEqual(view.ViewportLeft, scrollBar.Maximum, 0.01,
+                "the scrollbar's drag ceiling must be the viewport's own");
+
+            host.Close();
+        }).ConfigureAwait(false);
+    }
+
+    [TestMethod]
+    public async Task HorizontalScrollBarEndsClearOfTheVerticalScrollBar()
+    {
+        await HeadlessEditor.RunAsync(() =>
+        {
+            string text = string.Join('\n', Enumerable.Range(0, 100).Select(i => $"line {i}"));
+            var view = HeadlessEditor.CreateView(text, height: 300.0);
+            var factory = HeadlessEditor.Container.GetExport<ITextEditorFactoryService>();
+            var host = factory.CreateTextViewHost(view, setFocus: false);
+            var window = new Avalonia.Controls.Window { Width = 400, Height = 300, Content = host.HostControl };
+            window.Show();
+
+            try
+            {
+                Avalonia.Threading.Dispatcher.UIThread.RunJobs();
+
+                // The bottom row must stay clear of the vertical scrollbar's lane.
+                var right = (IWpfTextViewMargin)host.GetTextViewMargin(PredefinedMarginNames.Right)!;
+                var bottom = (IWpfTextViewMargin)host.GetTextViewMargin(PredefinedMarginNames.Bottom)!;
+                Assert.IsTrue(right.VisualElement.Bounds.Width > 0, "the probe needs the vertical bar's lane laid out");
+                Assert.AreEqual(right.VisualElement.Bounds.Width, bottom.VisualElement.Margin.Right, 0.01,
+                    "the bottom row must end where the right container begins");
+            }
+            finally
+            {
+                window.Close();
+                host.Close();
+            }
+        }).ConfigureAwait(false);
+    }
+
+    [TestMethod]
     public async Task VerticalScrollBarMapsBufferPositionsAndScrollsTheView()
     {
         await HeadlessEditor.RunAsync(() =>


### PR DESCRIPTION
Dragging the horizontal scrollbar's thumb travels further than wheel/keyboard scrolling ever goes, and the thumb can end up parked underneath the vertical scrollbar.

<img width="267" height="146" alt="grafik" src="https://github.com/user-attachments/assets/ac2fb6d8-8da4-4dc3-a25a-249480a05e4b" />

Two independent causes:

**The drag ceiling disagrees with the viewport's clamp.** `HorizontalScrollBarMargin` advertises `Maximum = MaxTextRightCoordinate + 20 − ViewportWidth`, while the `ViewportLeft` setter clamps at `MaxTextRightCoordinate + ColumnWidth − ViewportWidth`. Dragging into the ~13px difference keeps writing clamped `ViewportLeft` values that no longer change the viewport — so no `ViewportLeftChanged` fires, the margin never re-syncs `Value`, and the thumb parks past the content's edge until the next layout. Wheel and keyboard scrolling go through the viewport's own clamp and stop earlier, so the two input paths visibly disagree. The margin now derives `Maximum` from the same formula the viewport enforces (one column past the longest line).

**There is no corner between the overlay scrollbars.** The host overlays the right and bottom margin containers onto the same grid cell (VS Code-style floating bars), so the horizontal track runs on under the vertical scrollbar. The bottom container now keeps a right inset tracked from the right container's `SizeChanged`: the horizontal track ends where the vertical bar begins — the corner belongs to the vertical scrollbar, as in VS Code.

Two regression tests in `MarginTests`: the drag ceiling must equal the offset the viewport itself accepts (fails on the old `+ 20`), and the bottom row must end clear of the right container's lane.

Note: Claude Fable 5 Max (Anthropic) was used in developing this change. Please feel free to edit or rework this PR in any way. Please also decide on whether you want to keep the tests.